### PR TITLE
Enable GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             - name: Run PlatformIO
               run: pio ci --project-conf=platformio.ini .
             - name: List files
-              run: pwd && ls
+              run: pwd && ls -a && ls -alh .pio/build/d1_mini/
             - uses: actions/upload-artifact@v3
               with:
                   name: firmware-${{ matrix.environment }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,8 @@ jobs:
 
             - name: Run PlatformIO
               run: pio ci --project-conf=platformio.ini .
-
-# TODO: Add Artifact Upload
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: firmware-${{ matrix.environment }}
+                  path: |
+                      .pio/build/d1_mini/firmware.bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,38 @@ name: PlatformIO CI
 on: [push]
 
 jobs:
+
+    get_default_envs:
+        name: Gather Environments
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/cache@v3
+              with:
+                  path: |
+                      ~/.cache/pip
+                      ~/.platformio/.cache
+                  key: ${{ runner.os }}-pio
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: '3.9'
+            - name: Install PlatformIO Core
+            - name: Get default environments
+              id: envs
+              run: |
+                    echo "::set-output name=environments::$(pio project config --json-output | jq -cr '.[0][1][0][1]')"
+        outputs:
+            environments: ${{ steps.envs.outputs.environments }}
+
     build:
 
         runs-on: ${{ matrix.os }}
+        needs: get_default_envs
+
         strategy:
             matrix:
                 os: [ubuntu-latest]
+                environment: ${{ fromJSON(needs.get_default_envs.outputs.environments) }}
 
         defaults:
             run:
@@ -30,10 +56,9 @@ jobs:
 
             - name: Run PlatformIO
               run: pio run
-            - name: List files
-              run: pwd && ls -a && ls -alh ./build_output/
             - uses: actions/upload-artifact@v3
               with:
                   name: firmware-${{ matrix.environment }}
+                  # We need to specify the full path as currently upload-artifact doesn't respect the working-directory
                   path: |
                       ./SOFTWARE/AfterlifeLightKit/build_output/d1_mini/firmware.bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
               run: pip install --upgrade platformio
 
             - name: Run PlatformIO
-              run: pio run
+              run: pio run -e ${{ matrix.environment }}
             - uses: actions/upload-artifact@v3
               with:
                   name: firmware-${{ matrix.environment }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+    build:
+
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-latest]
+
+        defaults:
+            run:
+                working-directory: ./SOFTWARE/AfterlifeLightKit
+
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/cache@v3
+              with:
+                  path: |
+                      ~/.cache/pip
+                      ~/.platformio/.cache
+                  key: ${{ runner.os }}-pio
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: '3.9'
+            - name: Install PlatformIO Core
+              run: pip install --upgrade platformio
+
+            - name: Run PlatformIO
+              run: pio ci --project-conf=platformio.ini .
+
+# TODO: Add Artifact Upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
               run: pip install --upgrade platformio
 
             - name: Run PlatformIO
-              run: pio ci --project-conf=platformio.ini .
+              run: pio run
             - name: List files
-              run: pwd && ls -a && ls -alh .pio/build/d1_mini/
+              run: pwd && ls -a && ls -alh ./build_output/
             - uses: actions/upload-artifact@v3
               with:
                   name: firmware-${{ matrix.environment }}
                   path: |
-                      ./SOFTWARE/AfterlifeLightKit/.pio/build/d1_mini/firmware.bin
+                      ./SOFTWARE/AfterlifeLightKit/build_output/d1_mini/firmware.bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             - name: Get default environments
               id: envs
               run: |
-                    echo "::set-output name=environments::$(pio project config --json-output | jq -cr '.[0][1][0][1]')"
+                    echo "environments=$(pio project config --json-output | jq -cr '.[0][1][0][1]')" >> $GITHUB_OUTPUT
         outputs:
             environments: ${{ steps.envs.outputs.environments }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ jobs:
         name: Gather Environments
         runs-on: ubuntu-latest
 
+        defaults:
+            run:
+                working-directory: ./SOFTWARE/AfterlifeLightKit
+
         steps:
             - uses: actions/checkout@v3
             - uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,4 +67,4 @@ jobs:
                   name: firmware-${{ matrix.environment }}
                   # We need to specify the full path as currently upload-artifact doesn't respect the working-directory
                   path: |
-                      ./SOFTWARE/AfterlifeLightKit/build_output/d1_mini/firmware.bin
+                      ./SOFTWARE/AfterlifeLightKit/build_output/${{ matrix.environment }}/firmware.bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
 
             - name: Run PlatformIO
               run: pio ci --project-conf=platformio.ini .
+            - name: List files
+              run: pwd && ls
             - uses: actions/upload-artifact@v3
               with:
                   name: firmware-${{ matrix.environment }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
               with:
                   name: firmware-${{ matrix.environment }}
                   path: |
-                      .pio/build/d1_mini/firmware.bin
+                      ./SOFTWARE/AfterlifeLightKit/.pio/build/d1_mini/firmware.bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     get_default_envs:
         name: Gather Environments
         runs-on: ubuntu-latest
+
         steps:
             - uses: actions/checkout@v3
             - uses: actions/cache@v3
@@ -19,6 +20,7 @@ jobs:
               with:
                   python-version: '3.9'
             - name: Install PlatformIO Core
+              run: pip install --upgrade platformio
             - name: Get default environments
               id: envs
               run: |

--- a/SOFTWARE/AfterlifeLightKit/.gitignore
+++ b/SOFTWARE/AfterlifeLightKit/.gitignore
@@ -1,1 +1,2 @@
 .pio
+build_output

--- a/SOFTWARE/AfterlifeLightKit/platformio.ini
+++ b/SOFTWARE/AfterlifeLightKit/platformio.ini
@@ -10,6 +10,7 @@
 [platformio]
 src_dir  = ./src
 data_dir = ./data
+build_dir = ./build_output/
 
 [env]
 platform = expressif8266

--- a/SOFTWARE/AfterlifeLightKit/platformio.ini
+++ b/SOFTWARE/AfterlifeLightKit/platformio.ini
@@ -10,7 +10,7 @@
 [platformio]
 # Release / CI binaries
 # NOTE: This should be the FIRST configuration setting so it can be accessed via GitHub Actions
-default_envs = gbfans_d1_mini_v1, gbfans_d1_mini_v2
+default_envs = gbfans_d1_mini_v1
 
 # Paths to use
 src_dir  = ./src
@@ -45,7 +45,3 @@ board_build.filesystem = littlefs
 monitor_speed = 115200
 monitor_rts = 0
 monitor_dtr = 0
-
-# Second board
-[env:gbfans_d1_mini_v2]
-platform = expressif8266

--- a/SOFTWARE/AfterlifeLightKit/platformio.ini
+++ b/SOFTWARE/AfterlifeLightKit/platformio.ini
@@ -8,6 +8,11 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 [platformio]
+# Release / CI binaries
+# NOTE: This should be the FIRST configuration setting so it can be accessed via GitHub Actions
+default_envs = gbfans_d1_mini_v1, gbfans_d1_mini_v2
+
+# Paths to use
 src_dir  = ./src
 data_dir = ./data
 build_dir = ./build_output/
@@ -25,7 +30,8 @@ lib_ldf_mode = deep+
 ; https://github.com/FastLED/FastLED/issues/1397
 build_flags = -Dregister=
 
-[env:d1_mini]
+# The first D1-Mini based GBFans Board (2022 prototype)
+[env:gbfans_d1_mini_v1]
 platform = espressif8266
 framework = arduino
 board = d1_mini
@@ -40,3 +46,6 @@ monitor_speed = 115200
 monitor_rts = 0
 monitor_dtr = 0
 
+# Second board
+[env:gbfans_d1_mini_v2]
+platform = expressif8266


### PR DESCRIPTION
Implement GitHub Actions with Artifact Upload

NOTE: This is currently not feature-complete, as the web UI must be uploaded separately to the device via LittleFS.
We have a [documented solution here](https://github.com/gbfans/afterlife-lightkit/issues/17#issuecomment-1528968309) which will be implemented via a separate PR.